### PR TITLE
fix(errors): classify domain-object errors by fault — caller vs system

### DIFF
--- a/src/constraints/__snapshots__/assertDomainObjectIsSafeToManipulate.test.ts.snap
+++ b/src/constraints/__snapshots__/assertDomainObjectIsSafeToManipulate.test.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`assertDomainObjectIsSafeToManipulate should throw a helpful error if any of the properties are a nested object not explicitly defined 1`] = `
-"
-DomainObject 'Plant' is not safe to manipulate.
+"💥 DomainObjectNotSafeToManipulateError: DomainObject 'Plant' is not safe to manipulate.
 
 Specifically, the keys: ["pot"].
 
@@ -13,13 +12,11 @@ For example:
   class Plant ... {
     public static nested = { pot: ... };
   }
-\`\`\`
-    "
+\`\`\`"
 `;
 
 exports[`assertDomainObjectIsSafeToManipulate should throw a helpful error if any of the properties are an array with nested objects not explicitly defined 1`] = `
-"
-DomainObject 'Plant' is not safe to manipulate.
+"💥 DomainObjectNotSafeToManipulateError: DomainObject 'Plant' is not safe to manipulate.
 
 Specifically, the keys: ["pastPots"].
 
@@ -30,6 +27,5 @@ For example:
   class Plant ... {
     public static nested = { pastPots: ... };
   }
-\`\`\`
-    "
+\`\`\`"
 `;

--- a/src/constraints/assertDomainObjectIsSafeToManipulate.ts
+++ b/src/constraints/assertDomainObjectIsSafeToManipulate.ts
@@ -1,7 +1,11 @@
+import { MalfunctionError } from 'helpful-errors';
+
 import type { DomainObject } from '@src/instantiation/DomainObject';
 import { isOfDomainObject } from '@src/instantiation/inherit/isOfDomainObject';
 
-export class DomainObjectNotSafeToManipulateError extends Error {
+// .why = an undeclared nested domain object is a developer misconfiguration of the class (the fix is
+//   to add `static nested`), not a caller's bad input — so it is a MalfunctionError (exit 1, http 500)
+export class DomainObjectNotSafeToManipulateError extends MalfunctionError {
   constructor({
     unsafeKeys,
     className,
@@ -22,7 +26,7 @@ For example:
     public static nested = { ${unsafeKeys[0]}: ... };
   }
 \`\`\`
-    `;
+    `.trim();
     super(message);
   }
 }

--- a/src/instantiation/__snapshots__/DomainObject.test.ts.snap
+++ b/src/instantiation/__snapshots__/DomainObject.test.ts.snap
@@ -45,7 +45,7 @@ exports[`DomainObject .contract should stamp identity + key metadata onto the sc
 `;
 
 exports[`DomainObject validation Joi schema should throw a helpful error when does not pass joi schema 1`] = `
-"Errors on 1 properties were found while validating properties for domain object RocketShip.:
+"✋ HelpfulJoiValidationError: Errors on 1 properties were found while validating properties for domain object RocketShip.:
 [
   {
     "message": "\\"serialNumber\\" must be a valid GUID",
@@ -63,7 +63,7 @@ Props Provided:
 `;
 
 exports[`DomainObject validation Yup schema should throw a helpful error when does not pass schema 1`] = `
-"Errors were found while validating properties for domain object RocketShip.:
+"✋ HelpfulYupValidationError: Errors were found while validating properties for domain object RocketShip.:
 [
   "passengers must be less than or equal to 42"
 ]
@@ -77,7 +77,7 @@ Props Provided:
 `;
 
 exports[`DomainObject validation Zod schema should throw a helpful error when does not pass schema 1`] = `
-"Errors were found while validating properties for domain object RocketShip.:
+"✋ HelpfulZodValidationError: Errors were found while validating properties for domain object RocketShip.:
 [
   {
     "origin": "number",

--- a/src/instantiation/validate/HelpfulSchemaValidationError.ts
+++ b/src/instantiation/validate/HelpfulSchemaValidationError.ts
@@ -1,7 +1,11 @@
+import { ConstraintError } from 'helpful-errors';
+
 /**
  * .what = common base for every schema-library validation error (zod, joi, yup, ...)
  * .why = lets a single `instanceof HelpfulSchemaValidationError` recognize any schema
  *   validation failure. a new schema library extends this base — no consumer of the
  *   check (e.g. try-each hydration) needs to enumerate a closed list of libraries
+ * .note = extends ConstraintError — a schema validation failure means the caller supplied
+ *   props that violate the declared shape (their fault), so exit code 2 + http 400 fit
  */
-export class HelpfulSchemaValidationError extends Error {}
+export class HelpfulSchemaValidationError extends ConstraintError {}

--- a/src/manipulation/DomainEntityPrimaryKeysMustBeDefinedError.ts
+++ b/src/manipulation/DomainEntityPrimaryKeysMustBeDefinedError.ts
@@ -1,4 +1,8 @@
-export class DomainEntityPrimaryKeysMustBeDefinedError extends Error {
+import { MalfunctionError } from 'helpful-errors';
+
+// .why = an absent `static primary` is a developer misconfiguration of the class, not a caller's
+//   bad input — so it is a MalfunctionError (exit 1, http 500), the system's fault to fix
+export class DomainEntityPrimaryKeysMustBeDefinedError extends MalfunctionError {
   constructor({
     entityName,
     nameOfFunctionNeededFor,
@@ -21,7 +25,7 @@ Example:
     public static primary = ['uuid'];
   }
   \`\`\`
-    `;
+    `.trim();
     super(message);
   }
 }

--- a/src/manipulation/DomainEntityUniqueKeysMustBeDefinedError.ts
+++ b/src/manipulation/DomainEntityUniqueKeysMustBeDefinedError.ts
@@ -1,4 +1,8 @@
-export class DomainEntityUniqueKeysMustBeDefinedError extends Error {
+import { MalfunctionError } from 'helpful-errors';
+
+// .why = an absent `static unique` is a developer misconfiguration of the class, not a caller's
+//   bad input — so it is a MalfunctionError (exit 1, http 500), the system's fault to fix
+export class DomainEntityUniqueKeysMustBeDefinedError extends MalfunctionError {
   constructor({
     entityName,
     nameOfFunctionNeededFor,
@@ -20,7 +24,7 @@ Example:
     public static unique = ['serialNumber'];
   }
   \`\`\`
-    `;
+    `.trim();
     super(message);
   }
 }

--- a/src/manipulation/DomainEntityUpdatablePropertiesMustBeDefinedError.ts
+++ b/src/manipulation/DomainEntityUpdatablePropertiesMustBeDefinedError.ts
@@ -1,4 +1,8 @@
-export class DomainEntityUpdatablePropertiesMustBeDefinedError extends Error {
+import { MalfunctionError } from 'helpful-errors';
+
+// .why = an absent `static updatable` is a developer misconfiguration of the class, not a caller's
+//   bad input — so it is a MalfunctionError (exit 1, http 500), the system's fault to fix
+export class DomainEntityUpdatablePropertiesMustBeDefinedError extends MalfunctionError {
   constructor({
     entityName,
     nameOfFunctionNeededFor,
@@ -20,7 +24,7 @@ Example:
     public static updatable = ['fuelQuantity', 'passengers];
   }
   \`\`\`
-    `;
+    `.trim();
     super(message);
   }
 }

--- a/src/manipulation/DomainObjectMetadataMustBeDefinedError.ts
+++ b/src/manipulation/DomainObjectMetadataMustBeDefinedError.ts
@@ -1,6 +1,8 @@
-import { HelpfulError } from 'helpful-errors';
+import { MalfunctionError } from 'helpful-errors';
 
-export class DomainObjectMetadataMustBeDefinedError extends HelpfulError {
+// .why = an absent `static metadata` is a developer misconfiguration of the class, not a caller's
+//   bad input — so it is a MalfunctionError (exit 1, http 500), the system's fault to fix
+export class DomainObjectMetadataMustBeDefinedError extends MalfunctionError {
   constructor({
     domainObjectName,
     nameOfFunctionNeededFor,
@@ -27,7 +29,7 @@ Example:
     public static metadata = ['uuid'] as const;
   }
   \`\`\`
-    `;
+    `.trim();
     super(message, { domainObjectName, nameOfFunctionNeededFor });
   }
 }

--- a/src/manipulation/serde/__snapshots__/deserialize.test.ts.snap
+++ b/src/manipulation/serde/__snapshots__/deserialize.test.ts.snap
@@ -95,11 +95,9 @@ Spaceship {
 exports[`deserialize domain objects should throw a JSON parse error when given invalid JSON 1`] = `"Expected property name or '}' in JSON at position 2 (line 1 column 3)"`;
 
 exports[`deserialize domain objects should throw a helpful error if attempted to deserialize a domain object without its constructor being provided in the context 1`] = `
-"
-DomainObject 'Spaceship' was referenced in the string being deserialized but was missing from the context given to the deserialize method.
+"💥 DeserializationMissingDomainObjectClassError: DomainObject 'Spaceship' was referenced in the string being deserialized but was missing from the context given to the deserialize method.
 
-Please make sure all DomainObjects serialized in the string have their classes defined in the context given to the deserialize method, using the 'with' property.
-    "
+Please make sure all DomainObjects serialized in the string have their classes defined in the context given to the deserialize method, using the 'with' property."
 `;
 
 exports[`deserialize objects should be able to serialize an object with all sorts of types 1`] = `

--- a/src/manipulation/serde/deserialize.ts
+++ b/src/manipulation/serde/deserialize.ts
@@ -1,16 +1,20 @@
+import { MalfunctionError } from 'helpful-errors';
+
 import type {
   DomainObject,
   DomainObjectInstantiationOptions,
 } from '@src/instantiation/DomainObject';
 import type { WithImmute } from '@src/manipulation/immute/withImmute';
 
-export class DeserializationMissingDomainObjectClassError extends Error {
+// .why = a class absent from the deserialize context is a developer setup bug (the fix is to register
+//   the class via `with`), not a caller's bad input — so it is a MalfunctionError (exit 1, http 500)
+export class DeserializationMissingDomainObjectClassError extends MalfunctionError {
   constructor({ className }: { className: string }) {
     const message = `
 DomainObject '${className}' was referenced in the string being deserialized but was missing from the context given to the deserialize method.
 
 Please make sure all DomainObjects serialized in the string have their classes defined in the context given to the deserialize method, using the 'with' property.
-    `;
+    `.trim();
     super(message);
   }
 }


### PR DESCRIPTION
fix(errors): classify domain-object errors by fault — caller vs system

- schema validation failures (zod/joi/yup) now extend ConstraintError
  (exit 2, http 400, ✋) — the caller supplied props that violate the shape
- class-misconfig errors (primary/unique/updatable/metadata must-be-defined,
  not-safe-to-manipulate, deserialize absent class) now extend MalfunctionError
  (exit 1, http 500, 💥) — the class was set up wrong, the system's fault
- trimmed message templates so the emoji + class-name prefix sits cleanly on
  the first line
- updated snapshots to reflect the richer prefixes

---
🐢🌊 surfed in by seaturtle[bot]